### PR TITLE
Changed Frontmatter regex pattern to allow for CRLF line endings.

### DIFF
--- a/src/Yosymfony/Spress/ContentManager/Frontmatter.php
+++ b/src/Yosymfony/Spress/ContentManager/Frontmatter.php
@@ -8,7 +8,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
- 
+
 namespace Yosymfony\Spress\ContentManager;
 
 use Yosymfony\Spress\Configuration;
@@ -16,7 +16,7 @@ use Yosymfony\Spress\Configuration;
 /**
  * Frontmatter is the configuration seccion of pages and posts.
  * The configuration is set between triple dashed lines.
- * 
+ *
  * @author Victor Puertas <vpgugr@gmail.com>
  */
 class Frontmatter
@@ -24,13 +24,13 @@ class Frontmatter
     private $content;
     private $configuration;
     private $repository;
-    private $pattern = '/^---\n(.*)\n?---\n?/isU';
+    private $pattern = '/^---\r*\n(.*)\r*\n?---\r*\n?/isU';
     private $fm;
     private $result = false;
-    
+
     /**
      * Constructor
-     * 
+     *
      * @param string $content
      * @param Yosymfony\Spress\Configuration $configuration Transform Front-matter to repository
      */
@@ -40,10 +40,10 @@ class Frontmatter
         $this->configuration = $configuration;
         $this->process();
     }
-    
+
     /**
      * Set a new Front-matter
-     * 
+     *
      * @param array Front-matter key-value set
      */
     public function setFrontmatter(array $frontmatter)
@@ -53,72 +53,72 @@ class Frontmatter
         $this->fm = '';
         $this->result = true;
     }
-    
+
     /**
      * The content has Front-matter?
-     * 
+     *
      * @return bool
      */
     public function hasFrontmatter()
-    {   
+    {
         return $this->result;
     }
-    
+
     /**
      * Get the Front-matter as string (no parsed)
-     * 
+     *
      * @return string FALSE if any problem occurs
      */
     public function getFrontmatterString()
     {
         $result = false;
-        
+
         if($this->hasFrontmatter())
         {
             $result = $this->fm;
         }
-        
+
         return $result;
     }
-    
+
     /**
      * Get Front-matter as array
-     * 
+     *
      * @return array
      */
     public function getFrontmatterArray()
     {
         return $this->repository->getRaw();
     }
-    
+
     /**
      * Get Front-matter as repository
-     * 
+     *
      * @return Yosymfony\Silex\ConfigServiceProvider\ConfigRepository
      */
     public function getFrontmatter()
     {
         return $this->repository;
     }
-    
+
     /**
      * @return string FALSE if any problem occurs
      */
     public function getFrontmatterWithDashedLines()
     {
         $result = false;
-        
+
         if ($this->hasFrontmatter())
         {
             $result = sprintf("---\n%s\n---", $this->fm);
         }
-        
+
         return $result;
     }
-    
+
     /**
      * Get content without Front-matter
-     * 
+     *
      * @return string
      */
     public function getContentNotFrontmatter()
@@ -126,17 +126,17 @@ class Frontmatter
         $result = preg_replace($this->pattern, '', $this->content, 1);
         return ltrim($result);
     }
-    
+
     private function process()
     {
         $result = preg_match($this->pattern, $this->content, $matches);
-        
+
         if(1 === $result)
         {
             $this->fm = $matches[1];
             $this->result = true;
         }
-        
+
         $this->repository = $this->configuration->getRepositoryInline($this->getFrontmatterString());
     }
 }


### PR DESCRIPTION
When creating pages or posts on the windows platform the .md files will use the CRLF line ending by default. Currently the regex in src/Yosymfony/Spress/ContentManager/Frontmatter.php only checks for the LF line ending which means that posts and pages do not appear to have frontmatter and will not be processed.

Altered the regex to account for both line ending types and now both CRLF and LF formatted files are processed.
