### PR TITLE
console new:post command change separator from space to comma for tags/cats

### DIFF
--- a/src/Command/NewPostCommand.php
+++ b/src/Command/NewPostCommand.php
@@ -35,8 +35,8 @@ class NewPostCommand extends Command
             new InputOption('title', '', InputOption::VALUE_REQUIRED, 'The name of the post'),
             new InputOption('layout', '', InputOption::VALUE_REQUIRED, 'The layout of the post'),
             new InputOption('date', '', InputOption::VALUE_REQUIRED, 'The date assigned to the post'),
-            new InputOption('tags', '', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Tags list separed by white spaces'),
-            new InputOption('categories', '', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Categories list separed by white spaces'),
+            new InputOption('tags', '', InputOption::VALUE_REQUIRED, 'Comma separated list of tags'),
+            new InputOption('categories', '', InputOption::VALUE_REQUIRED, 'Comma separated list of categories'),
         ])
         ->setName('new:post')
         ->setDescription('Generate a post')
@@ -59,8 +59,8 @@ EOT
         $title = Validators::validatePostTitle($input->getOption('title'));
         $layout = $input->getOption('layout');
         $date = $input->getOption('date') ?: $this->getDateFormated();
-        $tags = explode(' ', $input->getOption('tags') ?: '');
-        $categories = explode(' ', $input->getOption('categories') ?: '');
+        $tags = array_map('trim', explode(',', $input->getOption('tags') ?: ''));
+        $categories = array_map('trim', explode(',', $input->getOption('categories') ?: ''));
 
         $postsDir = './src/content/posts';
 
@@ -103,12 +103,12 @@ EOT
         $input->setOption('date', $date);
 
         $tags = $input->getOption('tags') ?: '';
-        $question = new Question('List of post tags separed by white space: ', $tags);
+        $question = new Question('Comma separated list of post tags: ', $tags);
         $tags = $helper->ask($input, $output, $question);
         $input->setOption('tags', $tags);
 
         $categories = $input->getOption('categories') ?: '';
-        $question = new Question('List of post categories separed by white space: ', $categories);
+        $question = new Question('Comma separated list of post categories: ', $categories);
         $categories = $helper->ask($input, $output, $question);
         $input->setOption('categories', $categories);
     }

--- a/tests/Command/NewPostCommandTest.php
+++ b/tests/Command/NewPostCommandTest.php
@@ -50,7 +50,7 @@ class NewPostCommandTest extends \PHPUnit_Framework_TestCase
         $commandTester = new CommandTester($command);
 
         $helper = $command->getHelper('question');
-        $helper->setInputStream($this->getInputStream("My first post\n\n\ntag1 tag2\ncategory1 category2\n"));
+        $helper->setInputStream($this->getInputStream("My first post\n\n\ntag1, tag2\ncategory1, category2\n"));
 
         $commandTester->execute([
             'command' => $command->getName(),
@@ -123,8 +123,8 @@ class NewPostCommandTest extends \PHPUnit_Framework_TestCase
             '--title' => 'My second post',
             '--layout' => 'post',
             '--date' => '2015-01-01',
-            '--tags' => 'tag1 tag2',
-            '--categories' => 'category1 category2',
+            '--tags' => 'tag1, tag2',
+            '--categories' => 'category1, category2',
         ]);
 
         $output = $commandTester->getDisplay();


### PR DESCRIPTION
I think space (` `) is a pretty popular character in category and tag names and it shouldn't be used as a separator for values while generating post via console.

This PR changes space to comma, and splits passed string into array also trimming the values to not to have spaces etc insite tag/category names.

I've updated command description and tests.