### PR TITLE
Improve permalinks customizations

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -19,6 +19,7 @@ timezone: 'UTC'                          # e.g. Europe/Madrid
 safe: false
 permalink: 'pretty'
 preserve_path_title: false
+no_html_extension: false
 layout_ext: ['html.twig', 'twig', 'html']
 url: ''                                  # e.g: http://your-domain.local:4000
 

--- a/src/Core/Configuration/Configuration.php
+++ b/src/Core/Configuration/Configuration.php
@@ -139,6 +139,7 @@ class Configuration implements ConfigurationInterface
             })
             ->setDefault('drafts', false, 'bool', true)
             ->setDefault('preserve_path_title', false, 'bool', true)
+            ->setDefault('no_html_extension', false, 'bool', true)
             ->setDefault('timezone', 'UTC', 'string', true)
             ->setDefault('url', '', 'string', true)
             ->setDefault('safe', false, 'bool', true)

--- a/src/Core/ContentManager/Permalink/PermalinkGenerator.php
+++ b/src/Core/ContentManager/Permalink/PermalinkGenerator.php
@@ -39,6 +39,16 @@ class PermalinkGenerator implements PermalinkGeneratorInterface
      * Predefined permalink 'none'
      */
     const PERMALINK_NONE = '/:path/:basename.:extension';
+    /**
+     * Predefined permalink template for 'date' & 'pretty'
+     * '/:collection' gets prepended when in a custom collection.
+     * 'pretty' also forces option 'no_html_extension'
+     */
+    const PERMALINK_DATE = '/:categories/:year/:month/:day/:title.:extension';
+    /**
+     * Predefined permalink 'ordinal'
+     */
+    const PERMALINK_ORDINAL = '/:categories/:year/:i_day/:title.:extension';
 
     private $defaultPermalink;
     private $defaultPreservePathTitle;
@@ -115,11 +125,10 @@ class PermalinkGenerator implements PermalinkGeneratorInterface
         switch ($permalinkStyle) {
             case 'none':
                 $urlTemplate = $this::PERMALINK_NONE;
-                $pathTemplate = $urlTemplate;
                 break;
             case 'ordinal':
                 if ($this->isItemWithDate($item)) {
-                    $urlTemplate = '/:categories/:year/:i_day/:title.:extension';
+                    $urlTemplate = $this::PERMALINK_ORDINAL;
 
                     if ($this->isCustomCollection($item)) {
                         $urlTemplate = '/:collection'.$urlTemplate;
@@ -127,27 +136,12 @@ class PermalinkGenerator implements PermalinkGeneratorInterface
                 } else {
                     $urlTemplate = $this::PERMALINK_NONE;
                 }
-
-                $pathTemplate = $urlTemplate;
-                break;
-            case 'date':
-                if ($this->isItemWithDate($item)) {
-                    $urlTemplate = '/:categories/:year/:month/:day/:title.:extension';
-
-                    if ($this->isCustomCollection($item)) {
-                        $urlTemplate = '/:collection'.$urlTemplate;
-                    }
-                } else {
-                    $urlTemplate = $this::PERMALINK_NONE;
-                }
-
-                $pathTemplate = $urlTemplate;
                 break;
             case 'pretty':
                 $noHtmlExtension = true;
-
+            case 'date':
                 if ($this->isItemWithDate($item)) {
-                    $urlTemplate = '/:categories/:year/:month/:day/:title';
+                    $urlTemplate = $this::PERMALINK_DATE;
 
                     if ($this->isCustomCollection($item)) {
                         $urlTemplate = '/:collection'.$urlTemplate;
@@ -155,8 +149,6 @@ class PermalinkGenerator implements PermalinkGeneratorInterface
                 } else {
                     $urlTemplate = $this::PERMALINK_NONE;
                 }
-
-                $pathTemplate = $urlTemplate;
                 break;
             default:
                 if (!$this->templateNeedsDate($permalinkStyle)
@@ -165,7 +157,6 @@ class PermalinkGenerator implements PermalinkGeneratorInterface
                 } else {
                     $urlTemplate = $this::PERMALINK_NONE;
                 }
-                $pathTemplate = $urlTemplate;
                 break;
         }
 
@@ -174,8 +165,9 @@ class PermalinkGenerator implements PermalinkGeneratorInterface
                 $placeholders[':basename'] = '';
             }
             $urlTemplate = str_replace(['.:extension', ':extension'], '', $urlTemplate);
-            $pathTemplate = str_replace(['.:extension', ':extension'], '', $pathTemplate);
-            $pathTemplate .= '/index.html';
+            $pathTemplate = $urlTemplate . '/index.html';
+        } else {
+            $pathTemplate = $urlTemplate;
         }
 
         $path = $this->generatePath($pathTemplate, $placeholders);

--- a/src/Core/ContentManager/Permalink/PermalinkGenerator.php
+++ b/src/Core/ContentManager/Permalink/PermalinkGenerator.php
@@ -139,12 +139,6 @@ class PermalinkGenerator implements PermalinkGeneratorInterface
                 $pathTemplate = $urlTemplate;
                 break;
             case 'pretty':
-                if ($placeholders[':extension'] !== 'html') {
-                    $urlTemplate = $this::PERMALINK_NONE;
-                    $pathTemplate = $urlTemplate;
-                    break;
-                }
-
                 if ($this->isItemWithDate($item)) {
                     $urlTemplate = '/:categories/:year/:month/:day/:title';
                     $pathTemplate = '/:categories/:year/:month/:day/:title/index.html';
@@ -154,12 +148,17 @@ class PermalinkGenerator implements PermalinkGeneratorInterface
                         $pathTemplate = '/:collection'.$pathTemplate;
                     }
                 } else {
-                    if ($placeholders[':basename'] === 'index') {
-                        $urlTemplate = '/:path';
-                        $pathTemplate = '/:path/index.html';
+                    if ($placeholders[':extension'] !== 'html') {
+                        $urlTemplate = $this::PERMALINK_NONE;
+                        $pathTemplate = $urlTemplate;
                     } else {
-                        $urlTemplate = '/:path/:basename';
-                        $pathTemplate = '/:path/:basename/index.html';
+                        if ($placeholders[':basename'] === 'index') {
+                            $urlTemplate = '/:path';
+                            $pathTemplate = '/:path/index.html';
+                        } else {
+                            $urlTemplate = '/:path/:basename';
+                            $pathTemplate = '/:path/:basename/index.html';
+                        }
                     }
                 }
                 break;

--- a/src/Core/ContentManager/Permalink/PermalinkGenerator.php
+++ b/src/Core/ContentManager/Permalink/PermalinkGenerator.php
@@ -34,6 +34,11 @@ use Yosymfony\Spress\Core\Support\StringWrapper;
  */
 class PermalinkGenerator implements PermalinkGeneratorInterface
 {
+    /**
+     * Predefined permalink 'none'
+     */
+    const PERMALINK_NONE = '/:path/:basename.:extension';
+
     private $defaultPermalink;
     private $defaultPreservePathTitle;
 
@@ -94,7 +99,7 @@ class PermalinkGenerator implements PermalinkGeneratorInterface
         $permalinkStyle = $this->getPermalinkAttribute($item);
 
         if ($item->isBinary() === true) {
-            $urlTemplate = '/:path/:basename.:extension';
+            $urlTemplate = $this::PERMALINK_NONE;
             $path = $this->generatePath($urlTemplate, $placeholders);
             $urlPath = $this->generateUrlPath($urlTemplate, $placeholders);
 
@@ -103,8 +108,7 @@ class PermalinkGenerator implements PermalinkGeneratorInterface
 
         switch ($permalinkStyle) {
             case 'none':
-                $urlTemplate = '/:path/:basename.:extension';
-
+                $urlTemplate = $this::PERMALINK_NONE;
                 $pathTemplate = $urlTemplate;
                 break;
             case 'ordinal':
@@ -115,7 +119,7 @@ class PermalinkGenerator implements PermalinkGeneratorInterface
                         $urlTemplate = '/:collection'.$urlTemplate;
                     }
                 } else {
-                    $urlTemplate = '/:path/:basename.:extension';
+                    $urlTemplate = $this::PERMALINK_NONE;
                 }
 
                 $pathTemplate = $urlTemplate;
@@ -128,14 +132,14 @@ class PermalinkGenerator implements PermalinkGeneratorInterface
                         $urlTemplate = '/:collection'.$urlTemplate;
                     }
                 } else {
-                    $urlTemplate = '/:path/:basename.:extension';
+                    $urlTemplate = $this::PERMALINK_NONE;
                 }
 
                 $pathTemplate = $urlTemplate;
                 break;
             case 'pretty':
                 if ($placeholders[':extension'] !== 'html') {
-                    $urlTemplate = '/:path/:basename.:extension';
+                    $urlTemplate = $this::PERMALINK_NONE;
                     $pathTemplate = $urlTemplate;
                     break;
                 }

--- a/src/Core/Spress.php
+++ b/src/Core/Spress.php
@@ -253,8 +253,9 @@ class Spress extends Container
         $this['spress.cms.permalinkGenerator'] = function ($c) {
             $permalink = $c['spress.config.values']['permalink'];
             $preservePathTitle = $c['spress.config.values']['preserve_path_title'];
+            $noHtmlExtension = $c['spress.config.values']['no_html_extension'];
 
-            return new PermalinkGenerator($permalink, $preservePathTitle);
+            return new PermalinkGenerator($permalink, $preservePathTitle, $noHtmlExtension);
         };
 
         $this['spress.cms.renderizer'] = function ($c) {

--- a/src/Core/Tests/Configuration/ConfigurationTest.php
+++ b/src/Core/Tests/Configuration/ConfigurationTest.php
@@ -36,6 +36,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('pretty', $values['permalink']);
         $this->assertEquals('', $values['url']);
         $this->assertFalse($values['preserve_path_title']);
+        $this->assertFalse($values['no_html_extension']);
 
         $this->assertTrue(is_array($values['layout_ext']));
         $this->assertCount(3, $values['layout_ext']);
@@ -70,6 +71,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://spress.yosymfony.com', $values['url']);
         $this->assertEquals('pretty', $values['permalink']);
         $this->assertFalse($values['preserve_path_title']);
+        $this->assertFalse($values['no_html_extension']);
 
         $this->assertTrue(is_array($values['layout_ext']));
         $this->assertCount(3, $values['layout_ext']);

--- a/src/Core/Tests/ContentManager/Permalink/PermalinkGeneratorTest.php
+++ b/src/Core/Tests/ContentManager/Permalink/PermalinkGeneratorTest.php
@@ -224,6 +224,30 @@ class PermalinkGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/title-post/index.html', $permalink->getUrlPath());
     }
 
+    public function testNoHtmlExtension()
+    {
+        $pmg = new PermalinkGenerator('/:year-:month-:day/:title.:extension', false, true);
+        $permalink = $pmg->getPermalink($this->createItem('index.html'));
+
+        $this->assertEquals('index.html', $permalink->getPath());
+        $this->assertEquals('/', $permalink->getUrlPath());
+
+        $permalink = $pmg->getPermalink($this->createItem('index.html', [
+            'date' => '2015-04-17',
+        ]));
+
+        $this->assertEquals('2015-04-17/index.html', $permalink->getPath());
+        $this->assertEquals('/2015-04-17', $permalink->getUrlPath());
+
+        $permalink = $pmg->getPermalink($this->createItem('index.html', [
+            'date' => '2015-04-17',
+            'title' => 'my first post',
+        ]));
+
+        $this->assertEquals('2015-04-17/my-first-post/index.html', $permalink->getPath());
+        $this->assertEquals('/2015-04-17/my-first-post', $permalink->getUrlPath());
+    }
+
     public function testPermalinkForBinaryItem()
     {
         $pmg = new PermalinkGenerator('pretty');

--- a/src/Core/config/default.yml
+++ b/src/Core/config/default.yml
@@ -16,6 +16,7 @@ timezone: 'UTC'                          # e.g. Europe/Madrid
 safe: false
 permalink: 'pretty'
 preserve_path_title: false
+no_html_extension: false
 layout_ext: ['html.twig', 'twig', 'html']
 url: ''                                  # e.g: http://your-domain.local:4000
 


### PR DESCRIPTION
As I was trying out Spress and looking into permalinks, I noticed a few "flaws"
in the way it works, and how some things seemed impossible to be done, so I
looked into addressing them, resulting in those patches.

Specifically, I think that falling back to the current date when an item doesn't
have an attribute "date" is useless (I can't imagine anyone who'd like a page to
have a different URL based on the date of generation of the site), as
illustrated by the fact that predefined permalinks do not actually work that
way, but instead fallback to permalink "none" when there's no "date" attribute.

I think this should in fact have been the behavior for user-defined permalinks
as well, makes (more) sense and also makes things consistent. So now if
date-related variables are used in a user-defined permalink, but there's no
"date" attribute, simply fallback to "none".

Another thing was that "pretty" also came with a special "extensionless" mode,
which wasn't available by any other means. As a result, if one wanted to use
that mode but with a different template for its permalink, it simply wasn't
possible.

So a patch adds a new option "no_html_extension" which, when true, enables this
"extensionless" mode (for items resulting in "html" files only, ofc). What it basically
does is remove ":extension" and ".:extension" from the permalink, then use the
result as link (urlPath), and adds "/index.html" for the generated file (path) 

As a result "pretty" is simply the same permalink as "date" only with
"no_html_extension" forced enabled.
And of course, it is possible to enable "no_html_extension" with any user-defined
permalink as well.