### PR TITLE
TwigRenderizer: add addTwigTag()

### DIFF
--- a/src/Core/ContentManager/Renderizer/TwigRenderizer.php
+++ b/src/Core/ContentManager/Renderizer/TwigRenderizer.php
@@ -185,6 +185,18 @@ class TwigRenderizer implements RenderizerInterface
         $this->twig->addTest($twigTest);
     }
 
+    /**
+     * Adds a new Twig tag.
+     *
+     * @see http://twig.sensiolabs.org/doc/advanced.html#tags Twig documentation.
+     *
+     * @param \Twig_TokenParser $tokenParser
+     */
+    public function addTwigTag(\Twig_TokenParser $tokenParser)
+    {
+        $this->twig->addTokenParser($tokenParser);
+    }
+
     protected function getLayoutAttribute(array $attributes, $contentName)
     {
         if (isset($attributes['layout']) === false) {

--- a/src/Core/Tests/ContentManager/Renderizer/TwigRenderizerTest.php
+++ b/src/Core/Tests/ContentManager/Renderizer/TwigRenderizerTest.php
@@ -104,6 +104,12 @@ class TwigRenderizerTest extends \PHPUnit_Framework_TestCase
         });
     }
 
+    public function testAddTwigTag()
+    {
+        $renderizer = $this->getRenderizer();
+        $renderizer->addTwigTag(new TwigTag);
+    }
+
     /**
      * @expectedException \Yosymfony\Spress\Core\ContentManager\Exception\AttributeValueException
      */
@@ -121,5 +127,18 @@ class TwigRenderizerTest extends \PHPUnit_Framework_TestCase
         $twig = new \Twig_Environment($twigLoader, ['autoescape' => false]);
 
         return new TwigRenderizer($twig, $twigLoader, ['twig']);
+    }
+}
+
+class TwigTag extends \Twig_TokenParser
+{
+    public function parse(\Twig_Token $token)
+    {
+        return new \Twig_Node_Text('test', $token->getLine());
+    }
+
+    public function getTag()
+    {
+        return 'test';
     }
 }


### PR DESCRIPTION
There were helpers to add filters, functions & tests, but not tags. So here we
go.