### PR TITLE
PermalinkGenerator: Keep title_path as-is with preserve_title_path

### DIFF
--- a/src/Core/ContentManager/Permalink/PermalinkGenerator.php
+++ b/src/Core/ContentManager/Permalink/PermalinkGenerator.php
@@ -226,7 +226,7 @@ class PermalinkGenerator implements PermalinkGeneratorInterface
         $preservePathTitle = $this->getPreservePathTitleAttribute($item);
 
         if ($preservePathTitle === true && isset($attributes['title_path']) === true) {
-            return (new StringWrapper($attributes['title_path']))->slug();
+            return $attributes['title_path'];
         }
 
         if (isset($attributes['title']) === true) {

--- a/src/Core/Tests/ContentManager/Permalink/PermalinkGeneratorTest.php
+++ b/src/Core/Tests/ContentManager/Permalink/PermalinkGeneratorTest.php
@@ -222,6 +222,15 @@ class PermalinkGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('title-post/index.html', $permalink->getPath());
         $this->assertEquals('/title-post/index.html', $permalink->getUrlPath());
+
+        $permalink = $pmg->getPermalink($this->createItem('index.html', [
+            'date' => '2015-04-17',
+            'title' => 'title post',
+            'title_path' => 'title-WITH-1.2.3',
+        ]));
+
+        $this->assertEquals('title-WITH-1.2.3/index.html', $permalink->getPath());
+        $this->assertEquals('/title-WITH-1.2.3/index.html', $permalink->getUrlPath());
     }
 
     public function testNoHtmlExtension()


### PR DESCRIPTION
This ensures e.g. dots are kept (instead of replaced with dashes) and case is
preserved.